### PR TITLE
Upgrade `dhall-haskell`

### DIFF
--- a/Prelude/Integer/multiply.dhall
+++ b/Prelude/Integer/multiply.dhall
@@ -1,5 +1,4 @@
 --| `multiply m n` computes `m * n`.
-
 let nonPositive =
         ./nonPositive.dhall sha256:e00a852eed5b84ff60487097d8aadce53c9e5301f53ff4954044bd68949fac3b
       ? ./nonPositive.dhall

--- a/Prelude/JSON/Format.dhall
+++ b/Prelude/JSON/Format.dhall
@@ -4,5 +4,4 @@ An internal type used by `./renderAs` to select the output format.
 You should not need to use this type directly, simply use `./render`
 or `./renderYAML` as appropriate.
 -}
-
 < YAML | JSON >

--- a/Prelude/JSON/renderAs.dhall
+++ b/Prelude/JSON/renderAs.dhall
@@ -1,5 +1,4 @@
 --| Render a `JSON` value as `Text` in either JSON or YAML format.
-
 let JSON =
         ./core.dhall sha256:5dc1135d5481cfd6fde625aaed9fcbdb7aa7c14f2e76726aa5fdef028a5c10f5
       ? ./core.dhall

--- a/Prelude/JSON/renderInteger.dhall
+++ b/Prelude/JSON/renderInteger.dhall
@@ -2,7 +2,6 @@
 Render an `Integer` value as a `JSON number`, according to the JSON standard, in
 which a number may not start with a plus sign (`+`).
 -}
-
 let Integer/nonNegative =
         ../Integer/nonNegative.dhall sha256:b463373f070df6b1c8c7082051e0810fee38b360bab35256187c8c2b6af5c663
       ? ../Integer/nonNegative.dhall

--- a/Prelude/JSON/renderYAML.dhall
+++ b/Prelude/JSON/renderYAML.dhall
@@ -8,7 +8,6 @@ However, it is useful for debugging `JSON` values or for tests.
 For anything more sophisticated you should use `dhall-to-json` or
 `dhall-to-yaml`.
 -}
-
 let JSON =
         ./core.dhall sha256:5dc1135d5481cfd6fde625aaed9fcbdb7aa7c14f2e76726aa5fdef028a5c10f5
       ? ./core.dhall

--- a/Prelude/List/unpackOptionals.dhall
+++ b/Prelude/List/unpackOptionals.dhall
@@ -1,5 +1,4 @@
 --| Unpack Optionals in a List, omitting None items.
-
 let List/concatMap =
         ./concatMap.dhall sha256:3b2167061d11fda1e4f6de0522cbe83e0d5ac4ef5ddf6bb0b2064470c5d3fb64
       ? ./concatMap.dhall

--- a/Prelude/Map/unpackOptionals.dhall
+++ b/Prelude/Map/unpackOptionals.dhall
@@ -1,6 +1,5 @@
 --| Turn a `Map k (Optional v)` into a `Map k v` by dropping all
 --  entries with value `None`.
-
 let List/concatMap =
         ../List/concatMap.dhall sha256:3b2167061d11fda1e4f6de0522cbe83e0d5ac4ef5ddf6bb0b2064470c5d3fb64
       ? ../List/concatMap.dhall

--- a/Prelude/Text/replicate.dhall
+++ b/Prelude/Text/replicate.dhall
@@ -1,5 +1,4 @@
 --| Build a Text by copying the given Text the specified number of times
-
 let concat =
         ./concat.dhall sha256:731265b0288e8a905ecff95c97333ee2db614c39d69f1514cb8eed9259745fc0
       ? ./concat.dhall

--- a/Prelude/Text/spaces.dhall
+++ b/Prelude/Text/spaces.dhall
@@ -4,7 +4,6 @@ Return a Text with the number of spaces specified.
 This function is particularly helpful when trying to generate Text where
 whitespace is significant, i.e. with nested indentation.
 -}
-
 let replicate =
         ./replicate.dhall sha256:1b398b1d464b3a6c7264a690ac3cacb443b5683b43348c859d68e7c2cb925c4f
       ? ./replicate.dhall

--- a/Prelude/XML/Type.dhall
+++ b/Prelude/XML/Type.dhall
@@ -44,7 +44,6 @@ For example, the following XML element:
    }
 ```
 -}
-
 let XML/Type
     : Type
     = ∀(XML : Type) →

--- a/Prelude/XML/attribute.dhall
+++ b/Prelude/XML/attribute.dhall
@@ -1,5 +1,4 @@
 --| Builds a key-value record with a Text key and value.
-
 let attribute
     : Text → Text → { mapKey : Text, mapValue : Text }
     = λ(key : Text) → λ(value : Text) → { mapKey = key, mapValue = value }

--- a/Prelude/XML/element.dhall
+++ b/Prelude/XML/element.dhall
@@ -18,8 +18,6 @@ in  XML.render
 = "<foo><bar n=\"1\"/><baz n=\"2\"/></foo>"
 ```
 -}
-
-
 let XML =
         ./Type.dhall sha256:461930f3aab769ba537d1a4fd71f411504b0c8d1c1a78d65177be8ded0df8a5c
       ? ./Type.dhall

--- a/Prelude/XML/emptyAttributes.dhall
+++ b/Prelude/XML/emptyAttributes.dhall
@@ -1,3 +1,2 @@
 --| Create an empty XML attribute List.
-
 [] : List { mapKey : Text, mapValue : Text }

--- a/Prelude/XML/leaf.dhall
+++ b/Prelude/XML/leaf.dhall
@@ -9,7 +9,6 @@ in  XML.render (XML.leaf { name = "foobar", attributes = XML.emptyAttributes })
 = "<foobar/>"
 ```
 -}
-
 let XML =
         ./Type.dhall sha256:461930f3aab769ba537d1a4fd71f411504b0c8d1c1a78d65177be8ded0df8a5c
       ? ./Type.dhall

--- a/Prelude/XML/render.dhall
+++ b/Prelude/XML/render.dhall
@@ -22,7 +22,6 @@ in  XML.render
 ```
 
 -}
-
 let XML =
         ./Type.dhall sha256:461930f3aab769ba537d1a4fd71f411504b0c8d1c1a78d65177be8ded0df8a5c
       ? ./Type.dhall

--- a/Prelude/XML/text.dhall
+++ b/Prelude/XML/text.dhall
@@ -14,7 +14,6 @@ in  XML.render
 = "<location>/foo/bar</location>"
 ```
 -}
-
 let XML =
         ./Type.dhall sha256:461930f3aab769ba537d1a4fd71f411504b0c8d1c1a78d65177be8ded0df8a5c
       ? ./Type.dhall

--- a/Prelude/package.dhall
+++ b/Prelude/package.dhall
@@ -35,7 +35,7 @@
       ./JSON/package.dhall sha256:79dfc281a05bc7b78f927e0da0c274ee5709b1c55c9e5f59499cb28e9d6f3ec0
     ? ./JSON/package.dhall
 , Text =
-      ./Text/package.dhall sha256:819a967038fbf6f28cc289fa2651e42835f70b326210c86e51acf48f46f913d8
+      ./Text/package.dhall sha256:46c53957c10bd4c332a5716d6e06068cd24ae1392ca171e6da31e30b9b33c07c
     ? ./Text/package.dhall
 , XML =
       ./XML/package.dhall sha256:137e7b106b2e9743970e5d37b21a165f2e40f56ab593a4dd10605c9acd686fc6

--- a/nixops/dhall-haskell.json
+++ b/nixops/dhall-haskell.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/dhall-lang/dhall-haskell.git",
-  "rev": "5c503f0a20e8f213de37ba5d55f58be764994007",
-  "date": "2020-09-10T21:59:50-07:00",
-  "path": "/nix/store/5pqmkvd1y373dniznibb8zjllb7wfnbg-dhall-haskell-5c503f0",
-  "sha256": "1gh17qra2jd52n6cidjn8wx2788r21yfmb9n33x8fyjy38v4piv2",
+  "rev": "eb0327c858509a91fa58f0148b3f68ac15fe06ac",
+  "date": "2020-10-20T21:12:39-07:00",
+  "path": "/nix/store/qx95jag4fil98gl6q1h80r4ycb9anqkb-dhall-haskell",
+  "sha256": "1p5s3hbrb1sakymd8mvx8mspqfrw9d83kj54m02db65gwi43cp1p",
   "fetchSubmodules": true,
   "deepClone": false,
   "leaveDotGit": false

--- a/tests/type-inference/success/preludeB.dhall
+++ b/tests/type-inference/success/preludeB.dhall
@@ -475,6 +475,8 @@
     , concatSep : ∀(separator : Text) → ∀(elements : List Text) → Text
     , default : ∀(o : Optional Text) → Text
     , defaultMap : ∀(a : Type) → ∀(f : a → Text) → ∀(o : Optional a) → Text
+    , replace :
+        ∀(needle : Text) → ∀(replacement : Text) → ∀(haystack : Text) → Text
     , replicate : ∀(num : Natural) → ∀(text : Text) → Text
     , show : Text → Text
     , spaces : ∀(a : Natural) → Text


### PR DESCRIPTION
This is necessary in order for CI to accept the `Text/replace` built-in.

This also incurs a few other cosmetic changes to Prelude files since
the formatter now strips trailing whitespace from comment headers.